### PR TITLE
Update build tools and fix CI.

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,12 +22,13 @@ init:
     cargo install mdbook-open-on-gh
 
 init-builder:
-    @just install-gh-bin https://github.com/rust-lang/mdBook/releases/download/v0.4.32/mdbook-v0.4.32-x86_64-unknown-linux-gnu.tar.gz mdbook
+    @just install-gh-bin https://github.com/rust-lang/mdBook/releases/download/v0.4.43/mdbook-v0.4.43-x86_64-unknown-linux-gnu.tar.gz mdbook
     cargo install mdbook-i18n-helpers
-    @just install-gh-bin https://github.com/tommilligan/mdbook-admonish/releases/download/v1.10.1/mdbook-admonish-v1.10.1-x86_64-unknown-linux-gnu.tar.gz mdbook-admonish
-    @just install-gh-bin https://github.com/slowsage/mdbook-pagetoc/releases/download/v0.1.7/mdbook-pagetoc-v0.1.7-x86_64-unknown-linux-gnu.tar.gz mdbook-pagetoc
-    @just install-gh-bin https://github.com/badboy/mdbook-mermaid/releases/download/v0.12.6/mdbook-mermaid-v0.12.6-x86_64-unknown-linux-gnu.tar.gz mdbook-mermaid
-    @just install-gh-bin https://github.com/badboy/mdbook-open-on-gh/releases/download/2.3.3/mdbook-open-on-gh-2.3.3-x86_64-unknown-linux-gnu.tar.gz mdbook-open-on-gh
+    @just install-gh-bin https://github.com/tommilligan/mdbook-admonish/releases/download/v1.18.0/mdbook-admonish-v1.18.0-x86_64-unknown-linux-gnu.tar.gz mdbook-admonish
+    mdbook-admonish install
+    @just install-gh-bin https://github.com/slowsage/mdbook-pagetoc/releases/download/v0.2.0/mdbook-pagetoc-v0.2.0-x86_64-unknown-linux-gnu.tar.gz mdbook-pagetoc
+    @just install-gh-bin https://github.com/badboy/mdbook-mermaid/releases/download/v0.14.1/mdbook-mermaid-v0.14.1-x86_64-unknown-linux-gnu.tar.gz mdbook-mermaid
+    @just install-gh-bin https://github.com/badboy/mdbook-open-on-gh/releases/download/2.4.3/mdbook-open-on-gh-2.4.3-x86_64-unknown-linux-gnu.tar.gz mdbook-open-on-gh
 
 install-gh-bin GITHUB_PATH BIN_NAME:
     @just _log-head "Installing {{BIN_NAME}} from {{GITHUB_PATH}} ..."


### PR DESCRIPTION
From CI failures, missing `mdbook-admonish install` will cause the HTML to fail to build, even after minor version changes.